### PR TITLE
Add onDrawStarted callback

### DIFF
--- a/signature_pad_flutter/example/lib/main.dart
+++ b/signature_pad_flutter/example/lib/main.dart
@@ -92,7 +92,6 @@ class SignaturePadExampleState extends State<SignaturePadExample> {
                 ),
                 new RaisedButton(
                   onPressed: isSignatureStarted ? _handleSavePng : null,
-                      _padController.hasSignature ? _handleSavePng : null,
                   child: new Text("Save as PNG"),
                   color: Colors.white,
                   textColor: Colors.black,

--- a/signature_pad_flutter/example/lib/main.dart
+++ b/signature_pad_flutter/example/lib/main.dart
@@ -86,7 +86,8 @@ class SignaturePadExampleState extends State<SignaturePadExample> {
                   textColor: Colors.black,
                 ),
                 new RaisedButton(
-                  onPressed: _handleSavePng,
+                  onPressed:
+                      _padController.hasSignature ? _handleSavePng : null,
                   child: new Text("Save as PNG"),
                   color: Colors.white,
                   textColor: Colors.black,

--- a/signature_pad_flutter/example/lib/main.dart
+++ b/signature_pad_flutter/example/lib/main.dart
@@ -32,10 +32,15 @@ class SignaturePadExample extends StatefulWidget {
 
 class SignaturePadExampleState extends State<SignaturePadExample> {
   SignaturePadController _padController;
+  bool isSignatureStarted = false;
 
   void initState() {
     super.initState();
-    _padController = new SignaturePadController();
+    _padController = new SignaturePadController(onDrawStart: () {
+      setState(() {
+        isSignatureStarted = true;
+      });
+    });
   }
 
   Widget build(BuildContext context) {
@@ -86,7 +91,7 @@ class SignaturePadExampleState extends State<SignaturePadExample> {
                   textColor: Colors.black,
                 ),
                 new RaisedButton(
-                  onPressed:
+                  onPressed: isSignatureStarted ? _handleSavePng : null,
                       _padController.hasSignature ? _handleSavePng : null,
                   child: new Text("Save as PNG"),
                   color: Colors.white,
@@ -101,7 +106,10 @@ class SignaturePadExampleState extends State<SignaturePadExample> {
   }
 
   void _handleClear() {
-    _padController.clear();
+    setState(() {
+      _padController.clear();
+      isSignatureStarted = false;
+    });
   }
 
   Future _handleSavePng() async {

--- a/signature_pad_flutter/lib/signature_pad_flutter.dart
+++ b/signature_pad_flutter/lib/signature_pad_flutter.dart
@@ -15,6 +15,9 @@ class SignaturePadController {
   void clear() => _delegate?.clear();
   Future<List<int>> toPng() => _delegate?.getPng();
   bool get hasSignature => _delegate.hasSignature;
+  Function onDrawStart;
+
+  SignaturePadController({this.onDrawStart});
 }
 
 abstract class _SignaturePadDelegate {
@@ -38,9 +41,11 @@ class SignaturePadState extends State<SignaturePadWidget>
     implements _SignaturePadDelegate {
   SignaturePadController _controller;
   List<SPPoint> allPoints = [];
+  bool isOnDrawStartCalled;
 
   SignaturePadState(this._controller, SignaturePadOptions opts) {
     this.opts = opts;
+    this.isOnDrawStartCalled = false;
     clear();
     on();
   }
@@ -78,6 +83,8 @@ class SignaturePadState extends State<SignaturePadWidget>
   }
 
   void handleTap(TapDownDetails details) {
+    handleDrawStartedCallback();
+
     var x = details.globalPosition.dx;
     var y = details.globalPosition.dy;
     var offs = new Offset(x, y);
@@ -88,12 +95,23 @@ class SignaturePadState extends State<SignaturePadWidget>
   }
 
   void handleDragUpdate(DragUpdateDetails details) {
+    handleDrawStartedCallback();
+
     var x = details.globalPosition.dx;
     var y = details.globalPosition.dy;
     var offs = new Offset(x, y);
     RenderBox refBox = context.findRenderObject();
     offs = refBox.globalToLocal(offs);
     strokeUpdate(new Point(offs.dx, offs.dy));
+  }
+
+  void handleDrawStartedCallback() {
+    if (!isOnDrawStartCalled) {
+      isOnDrawStartCalled = true;
+      if (_controller.onDrawStart != null) {
+        _controller.onDrawStart();
+      }
+    }
   }
 
   void handleDragEnd(DragEndDetails details) {
@@ -131,6 +149,7 @@ class SignaturePadState extends State<SignaturePadWidget>
     super.clear();
     if (mounted) {
       setState(() {
+        isOnDrawStartCalled = false;
         allPoints = [];
       });
     }


### PR DESCRIPTION
Currently this lib provides no way to reactively check if a signature has been started.

There is hasSignature, but 2 problems with it is that it throws a null ref if you try to use it right away and you can't react to the value changing to do something in your application.

An example of this issue is here: https://github.com/MisterJimson/signature-pad-dart/commit/5e721e3555a549b85e60b3d88672f10fdbcc8de8

I want to disable the button if no signature is present.

This PR adds a callback that can be used for that purpose, example is updated showing how to use it.

(Also it would be nice to have issues enabled on this repo, great lib!)